### PR TITLE
fix/feat/refactor/test/chore: バグ修正・品質改善・テスト追加・context導入・yaml.v3移行

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,39 @@
+# セッション引継ぎ
+
+## 現在の状況
+
+TODO.md の「追加2」セクションを上から順に消化中。以下の2件は完了済み（コミット済み・未プッシュ）：
+
+- [x] `service.go:85` — バージョンフィルタリングの `break` 削除
+- [x] `repository.go:114` — `QueryPackageManifests` の identifier 比較を `strings.EqualFold` に統一
+
+## 残タスク（TODO.md 「追加2」セクション、上から順）
+
+### バグ・不具合
+1. `main.go:52-54` — `ListenAndServe` のエラーハンドリング修正（`ErrServerClosed` 以外のエラーが無視される）
+2. `provider_common.go:27-35` — `detectArch` に `amd64`, `aarch64` 対応を追加
+
+### コード品質
+3. `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` を追加
+4. `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` に `io.LimitReader` を適用
+5. `types.go` — `InstallerType` の有効値を定数定義し、switch 文のハードコードを置換
+6. `provider_common.go` — `buildZipPortableVersions` と `buildInstallerVersions` の共通ロジック抽出
+7. `cache.go` — TTL期限切れエントリの定期削除（メモリリーク対策）
+8. `provider_common.go:12-14` — `httpClient` をグローバル変数からプロバイダー構造体のフィールドに注入
+
+### テスト
+9. `github.go`, `gitlab.go` の `httptest` モックサーバーによるユニットテスト追加
+
+### 機能追加
+10. 全層に `context.Context` を導入
+11. `gopkg.in/yaml.v2` → `v3` への移行
+
+## 作業ルール（CLAUDE.md 参照）
+
+- コマンドはプロジェクトルートのカレントディレクトリで直接実行する（`cd` や `-C` フラグは使わない）
+- タスク消化の都度、コミットする
+- TODO.md の完了項目にチェックを入れる
+
+## 未プッシュコミット
+
+`v0.1.1` タグ以降のコミットが未プッシュ。全タスク完了後にバージョンを上げてプッシュする想定。

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,38 +2,32 @@
 
 ## 現在の状況
 
-TODO.md の「追加2」セクションを上から順に消化中。以下の2件は完了済み（コミット済み・未プッシュ）：
+TODO.md の全タスク完了。
 
-- [x] `service.go:85` — バージョンフィルタリングの `break` 削除
-- [x] `repository.go:114` — `QueryPackageManifests` の identifier 比較を `strings.EqualFold` に統一
+## 完了タスク（今セッション）
 
-## 残タスク（TODO.md 「追加2」セクション、上から順）
+- [x] `main.go:52-54` — `ListenAndServe` のエラーハンドリング修正（`ErrServerClosed` 以外を `slog.Error` で報告）
+- [x] `provider_common.go:27-35` — `detectArch` に `amd64`, `aarch64` 別名を追加
+- [x] `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` を追加
+- [x] `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` に `io.LimitReader` を適用（1MB上限）
+- [x] `types.go` — `InstallerType` の有効値を定数化し switch 文のハードコードを置換
+- [x] `provider_common.go` — `buildVersions` ヘルパーで共通ロジックを統合
+- [x] `cache.go` — `StartCleanup` メソッドで TTL 期限切れエントリを定期削除
+- [x] `provider_common.go:12-14` — `httpClient` をグローバル変数からプロバイダー構造体のフィールドに注入
+- [x] `github.go`, `gitlab.go` の `httptest` モックサーバーによるユニットテスト追加（`github_test.go`, `gitlab_test.go` 新規作成）
+- [x] 全層に `context.Context` を導入（Handler → Service → Repository → Provider）
+- [x] `gopkg.in/yaml.v2` → `v3` への移行
 
-### バグ・不具合
-1. `main.go:52-54` — `ListenAndServe` のエラーハンドリング修正（`ErrServerClosed` 以外のエラーが無視される）
-2. `provider_common.go:27-35` — `detectArch` に `amd64`, `aarch64` 対応を追加
+## 残タスク
 
-### コード品質
-3. `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` を追加
-4. `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` に `io.LimitReader` を適用
-5. `types.go` — `InstallerType` の有効値を定数定義し、switch 文のハードコードを置換
-6. `provider_common.go` — `buildZipPortableVersions` と `buildInstallerVersions` の共通ロジック抽出
-7. `cache.go` — TTL期限切れエントリの定期削除（メモリリーク対策）
-8. `provider_common.go:12-14` — `httpClient` をグローバル変数からプロバイダー構造体のフィールドに注入
+なし。全タスク完了。
 
-### テスト
-9. `github.go`, `gitlab.go` の `httptest` モックサーバーによるユニットテスト追加
+## 次のアクション
 
-### 機能追加
-10. 全層に `context.Context` を導入
-11. `gopkg.in/yaml.v2` → `v3` への移行
+`v0.1.1` タグ以降のコミットが未プッシュ。バージョンを上げてタグを打ちプッシュする。
 
 ## 作業ルール（CLAUDE.md 参照）
 
 - コマンドはプロジェクトルートのカレントディレクトリで直接実行する（`cd` や `-C` フラグは使わない）
 - タスク消化の都度、コミットする
 - TODO.md の完了項目にチェックを入れる
-
-## 未プッシュコミット
-
-`v0.1.1` タグ以降のコミットが未プッシュ。全タスク完了後にバージョンを上げてプッシュする想定。

--- a/TODO.md
+++ b/TODO.md
@@ -44,8 +44,8 @@
 
 ## バグ・不具合（追加2）
 
-- [ ] `service.go:85` — バージョンフィルタリングの `break` が不要。意図が不明確なので削除する
-- [ ] `repository.go:114` — `QueryPackageManifests` の identifier 比較が `==` で大文字小文字を区別している。`strings.EqualFold` に統一すべき
+- [x] `service.go:85` — バージョンフィルタリングの `break` が不要。意図が不明確なので削除する
+- [x] `repository.go:114` — `QueryPackageManifests` の identifier 比較が `==` で大文字小文字を区別している。`strings.EqualFold` に統一すべき
 - [ ] `main.go:52-54` — `ListenAndServe` のエラーハンドリングが不正。`ErrServerClosed` 以外のエラー（ポート競合等）が無視される
 - [ ] `provider_common.go:27-35` — `detectArch` が `amd64`, `aarch64` に未対応
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,3 +41,28 @@
 
 - [x] `cache.go` のユニットテスト追加（TTL期限切れ、Get/Set、並行アクセス）
 - [x] `provider_common.go` のユニットテスト追加（`detectArch`, `buildZipPortableVersions`, `buildInstallerVersions`）
+
+## バグ・不具合（追加2）
+
+- [ ] `service.go:85` — バージョンフィルタリングの `break` が不要。意図が不明確なので削除する
+- [ ] `repository.go:114` — `QueryPackageManifests` の identifier 比較が `==` で大文字小文字を区別している。`strings.EqualFold` に統一すべき
+- [ ] `main.go:52-54` — `ListenAndServe` のエラーハンドリングが不正。`ErrServerClosed` 以外のエラー（ポート競合等）が無視される
+- [ ] `provider_common.go:27-35` — `detectArch` が `amd64`, `aarch64` に未対応
+
+## コード品質（追加2）
+
+- [ ] `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` が未設定
+- [ ] `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` にサイズ上限がない（`io.LimitReader` を適用すべき）
+- [ ] `types.go` — `InstallerType` の有効値（`zip-portable`, `msi`, `exe`）が定数定義されていない。switch 文にハードコードされている
+- [ ] `provider_common.go` — `buildZipPortableVersions` と `buildInstallerVersions` の共通ロジックを抽出して重複を削減する
+- [ ] `cache.go` — TTL期限切れエントリがマップに残り続けメモリリークする。定期削除の仕組みを追加する
+- [ ] `provider_common.go:12-14` — `httpClient` がグローバル変数でテスト時のモック化が困難。プロバイダー構造体のフィールドに注入する
+
+## テスト（追加2）
+
+- [ ] `github.go`, `gitlab.go` のユニットテスト追加（`httptest` モックサーバーによるプロバイダー層テスト）
+
+## 機能追加（追加）
+
+- [ ] 全層に `context.Context` を導入し、キャンセル・タイムアウト制御を可能にする
+- [ ] `gopkg.in/yaml.v2` → `v3` への移行

--- a/TODO.md
+++ b/TODO.md
@@ -46,23 +46,23 @@
 
 - [x] `service.go:85` — バージョンフィルタリングの `break` が不要。意図が不明確なので削除する
 - [x] `repository.go:114` — `QueryPackageManifests` の identifier 比較が `==` で大文字小文字を区別している。`strings.EqualFold` に統一すべき
-- [ ] `main.go:52-54` — `ListenAndServe` のエラーハンドリングが不正。`ErrServerClosed` 以外のエラー（ポート競合等）が無視される
-- [ ] `provider_common.go:27-35` — `detectArch` が `amd64`, `aarch64` に未対応
+- [x] `main.go:52-54` — `ListenAndServe` のエラーハンドリングが不正。`ErrServerClosed` 以外のエラー（ポート競合等）が無視される
+- [x] `provider_common.go:27-35` — `detectArch` が `amd64`, `aarch64` に未対応
 
 ## コード品質（追加2）
 
-- [ ] `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` が未設定
-- [ ] `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` にサイズ上限がない（`io.LimitReader` を適用すべき）
-- [ ] `types.go` — `InstallerType` の有効値（`zip-portable`, `msi`, `exe`）が定数定義されていない。switch 文にハードコードされている
-- [ ] `provider_common.go` — `buildZipPortableVersions` と `buildInstallerVersions` の共通ロジックを抽出して重複を削減する
-- [ ] `cache.go` — TTL期限切れエントリがマップに残り続けメモリリークする。定期削除の仕組みを追加する
-- [ ] `provider_common.go:12-14` — `httpClient` がグローバル変数でテスト時のモック化が困難。プロバイダー構造体のフィールドに注入する
+- [x] `main.go:39-43` — HTTPサーバーに `ReadTimeout`, `WriteTimeout`, `IdleTimeout` が未設定
+- [x] `github.go:43`, `gitlab.go:47` — APIエラーレスポンスの `io.ReadAll` にサイズ上限がない（`io.LimitReader` を適用すべき）
+- [x] `types.go` — `InstallerType` の有効値（`zip-portable`, `msi`, `exe`）が定数定義されていない。switch 文にハードコードされている
+- [x] `provider_common.go` — `buildZipPortableVersions` と `buildInstallerVersions` の共通ロジックを抽出して重複を削減する
+- [x] `cache.go` — TTL期限切れエントリがマップに残り続けメモリリークする。定期削除の仕組みを追加する
+- [x] `provider_common.go:12-14` — `httpClient` がグローバル変数でテスト時のモック化が困難。プロバイダー構造体のフィールドに注入する
 
 ## テスト（追加2）
 
-- [ ] `github.go`, `gitlab.go` のユニットテスト追加（`httptest` モックサーバーによるプロバイダー層テスト）
+- [x] `github.go`, `gitlab.go` のユニットテスト追加（`httptest` モックサーバーによるプロバイダー層テスト）
 
 ## 機能追加（追加）
 
-- [ ] 全層に `context.Context` を導入し、キャンセル・タイムアウト制御を可能にする
-- [ ] `gopkg.in/yaml.v2` → `v3` への移行
+- [x] 全層に `context.Context` を導入し、キャンセル・タイムアウト制御を可能にする
+- [x] `gopkg.in/yaml.v2` → `v3` への移行

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -21,6 +22,30 @@ func NewCache[T any](ttl time.Duration) *Cache[T] {
 		entries: make(map[string]cacheEntry[T]),
 		ttl:     ttl,
 	}
+}
+
+// StartCleanup starts a background goroutine that periodically removes expired entries.
+// It stops when ctx is done.
+func (c *Cache[T]) StartCleanup(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				now := time.Now()
+				c.mu.Lock()
+				for k, e := range c.entries {
+					if now.After(e.expiresAt) {
+						delete(c.entries, k)
+					}
+				}
+				c.mu.Unlock()
+			}
+		}
+	}()
 }
 
 func (c *Cache[T]) Get(key string) (T, bool) {

--- a/github.go
+++ b/github.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Github struct {
+	httpClient *http.Client
 }
 
 type githubAsset struct {
@@ -33,7 +34,7 @@ func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
 		req.Header.Add("Authorization", fmt.Sprintf("token %s", entry.Token))
 	}
 
-	res, err := httpClient.Do(req)
+	res, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("github releases API: %w", err)
 	}
@@ -65,11 +66,11 @@ func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
 
 	switch entry.InstallerType {
 	case InstallerTypeZipPortable:
-		return buildZipPortableVersions(entry, releases)
+		return buildZipPortableVersions(g.httpClient, entry, releases)
 	case InstallerTypeMsi:
-		return buildInstallerVersions(entry, releases, InstallerTypeMsi, ".msi")
+		return buildInstallerVersions(g.httpClient, entry, releases, InstallerTypeMsi, ".msi")
 	case InstallerTypeExe:
-		return buildInstallerVersions(entry, releases, InstallerTypeExe, ".exe")
+		return buildInstallerVersions(g.httpClient, entry, releases, InstallerTypeExe, ".exe")
 	default:
 		return nil, fmt.Errorf("unknown installer type: %s", entry.InstallerType)
 	}

--- a/github.go
+++ b/github.go
@@ -64,12 +64,12 @@ func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
 	}
 
 	switch entry.InstallerType {
-	case "zip-portable":
+	case InstallerTypeZipPortable:
 		return buildZipPortableVersions(entry, releases)
-	case "msi":
-		return buildInstallerVersions(entry, releases, "msi", ".msi")
-	case "exe":
-		return buildInstallerVersions(entry, releases, "exe", ".exe")
+	case InstallerTypeMsi:
+		return buildInstallerVersions(entry, releases, InstallerTypeMsi, ".msi")
+	case InstallerTypeExe:
+		return buildInstallerVersions(entry, releases, InstallerTypeExe, ".exe")
 	default:
 		return nil, fmt.Errorf("unknown installer type: %s", entry.InstallerType)
 	}

--- a/github.go
+++ b/github.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,12 +26,12 @@ type githubRelease struct {
 }
 
 // FetchVersions implements PackageProvider.
-func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
+func (g Github) FetchVersions(ctx context.Context, entry PackageListEntry) ([]Version, error) {
 	baseURL := g.baseURL
 	if baseURL == "" {
 		baseURL = "https://api.github.com"
 	}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/releases", baseURL, entry.Id), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/releases", baseURL, entry.Id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("github releases API: %w", err)
 	}

--- a/github.go
+++ b/github.go
@@ -40,7 +40,7 @@ func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		contents, _ := io.ReadAll(res.Body)
+		contents, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 		return nil, fmt.Errorf("github releases API status %d: %s", res.StatusCode, contents)
 	}
 

--- a/github.go
+++ b/github.go
@@ -10,6 +10,7 @@ import (
 
 type Github struct {
 	httpClient *http.Client
+	baseURL    string
 }
 
 type githubAsset struct {
@@ -25,7 +26,11 @@ type githubRelease struct {
 
 // FetchVersions implements PackageProvider.
 func (g Github) FetchVersions(entry PackageListEntry) ([]Version, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://api.github.com/repos/%s/releases", entry.Id), nil)
+	baseURL := g.baseURL
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/%s/releases", baseURL, entry.Id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("github releases API: %w", err)
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,7 @@ func TestGithub_FetchVersions_ZipPortable(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	versions, err := g.FetchVersions(entry)
+	versions, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestGithub_FetchVersions_Msi(t *testing.T) {
 		InstallerType: InstallerTypeMsi,
 	}
 
-	versions, err := g.FetchVersions(entry)
+	versions, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -128,7 +129,7 @@ func TestGithub_FetchVersions_ErrorResponse(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err == nil {
 		t.Fatal("expected error for non-200 status")
 	}
@@ -150,7 +151,7 @@ func TestGithub_FetchVersions_UnknownInstallerType(t *testing.T) {
 		InstallerType: "unknown-type",
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err == nil {
 		t.Fatal("expected error for unknown installer type")
 	}
@@ -175,7 +176,7 @@ func TestGithub_FetchVersions_WithToken(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGithub_FetchVersions_ZipPortable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []githubRelease{
+			{
+				Name: "v1.0.0",
+				Assets: []githubAsset{
+					{
+						Name:               "myapp_windows_x64.zip",
+						BrowserDownloadUrl: "https://example.com/myapp_windows_x64.zip",
+						ContentType:        "application/zip",
+					},
+					{
+						Name:               "myapp_linux_x64.tar.gz",
+						BrowserDownloadUrl: "https://example.com/myapp_linux_x64.tar.gz",
+						ContentType:        "application/gzip",
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Github{httpClient: ts.Client(), baseURL: ts.URL}
+
+	entry := PackageListEntry{
+		Id:            "owner/myapp",
+		Name:          "myapp",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	versions, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+
+	if versions[0].Version != "v1.0.0" {
+		t.Errorf("expected version 'v1.0.0', got '%s'", versions[0].Version)
+	}
+
+	if len(versions[0].Installers) != 1 {
+		t.Fatalf("expected 1 installer, got %d", len(versions[0].Installers))
+	}
+
+	if versions[0].Installers[0].Architecture != "x64" {
+		t.Errorf("expected architecture 'x64', got '%s'", versions[0].Installers[0].Architecture)
+	}
+}
+
+func TestGithub_FetchVersions_Msi(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []githubRelease{
+			{
+				Name: "v2.0.0",
+				Assets: []githubAsset{
+					{
+						Name:               "myapp_windows_x64.msi",
+						BrowserDownloadUrl: "https://example.com/myapp_windows_x64.msi",
+						ContentType:        "application/octet-stream",
+					},
+					{
+						Name:               "myapp_windows_x86.msi",
+						BrowserDownloadUrl: "https://example.com/myapp_windows_x86.msi",
+						ContentType:        "application/octet-stream",
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Github{httpClient: ts.Client(), baseURL: ts.URL}
+
+	entry := PackageListEntry{
+		Id:            "owner/myapp",
+		Name:          "myapp",
+		InstallerType: InstallerTypeMsi,
+	}
+
+	versions, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+
+	if len(versions[0].Installers) != 2 {
+		t.Fatalf("expected 2 installers, got %d", len(versions[0].Installers))
+	}
+
+	for _, inst := range versions[0].Installers {
+		if inst.InstallerType != InstallerTypeMsi {
+			t.Errorf("expected InstallerType '%s', got '%s'", InstallerTypeMsi, inst.InstallerType)
+		}
+	}
+}
+
+func TestGithub_FetchVersions_ErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer ts.Close()
+
+	g := Github{httpClient: ts.Client(), baseURL: ts.URL}
+
+	entry := PackageListEntry{
+		Id:            "owner/myapp",
+		Name:          "myapp",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestGithub_FetchVersions_UnknownInstallerType(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []githubRelease{{Name: "v1.0.0"}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Github{httpClient: ts.Client(), baseURL: ts.URL}
+
+	entry := PackageListEntry{
+		Id:            "owner/myapp",
+		Name:          "myapp",
+		InstallerType: "unknown-type",
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err == nil {
+		t.Fatal("expected error for unknown installer type")
+	}
+}
+
+func TestGithub_FetchVersions_WithToken(t *testing.T) {
+	var gotToken string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("Authorization")
+		releases := []githubRelease{}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Github{httpClient: ts.Client(), baseURL: ts.URL}
+
+	entry := PackageListEntry{
+		Id:            "owner/myapp",
+		Name:          "myapp",
+		Token:         "mytoken",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotToken != "token mytoken" {
+		t.Errorf("expected Authorization header 'token mytoken', got '%s'", gotToken)
+	}
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Gitlab struct {
+	httpClient *http.Client
 }
 
 type gitlabAssetLink struct {
@@ -37,7 +38,7 @@ func (g Gitlab) FetchVersions(entry PackageListEntry) ([]Version, error) {
 		req.Header.Add("PRIVATE-TOKEN", entry.Token)
 	}
 
-	res, err := httpClient.Do(req)
+	res, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("gitlab releases API: %w", err)
 	}
@@ -69,11 +70,11 @@ func (g Gitlab) FetchVersions(entry PackageListEntry) ([]Version, error) {
 
 	switch entry.InstallerType {
 	case InstallerTypeZipPortable:
-		return buildZipPortableVersions(entry, releases)
+		return buildZipPortableVersions(g.httpClient, entry, releases)
 	case InstallerTypeMsi:
-		return buildInstallerVersions(entry, releases, InstallerTypeMsi, ".msi")
+		return buildInstallerVersions(g.httpClient, entry, releases, InstallerTypeMsi, ".msi")
 	case InstallerTypeExe:
-		return buildInstallerVersions(entry, releases, InstallerTypeExe, ".exe")
+		return buildInstallerVersions(g.httpClient, entry, releases, InstallerTypeExe, ".exe")
 	default:
 		return nil, fmt.Errorf("unknown installer type: %s", entry.InstallerType)
 	}

--- a/gitlab.go
+++ b/gitlab.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,8 +29,8 @@ type gitlabRelease struct {
 }
 
 // FetchVersions implements PackageProvider.
-func (g Gitlab) FetchVersions(entry PackageListEntry) ([]Version, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v4/projects/%d/releases", entry.Endpoint, entry.ProjectID), nil)
+func (g Gitlab) FetchVersions(ctx context.Context, entry PackageListEntry) ([]Version, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v4/projects/%d/releases", entry.Endpoint, entry.ProjectID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("gitlab releases API: %w", err)
 	}

--- a/gitlab.go
+++ b/gitlab.go
@@ -68,12 +68,12 @@ func (g Gitlab) FetchVersions(entry PackageListEntry) ([]Version, error) {
 	}
 
 	switch entry.InstallerType {
-	case "zip-portable":
+	case InstallerTypeZipPortable:
 		return buildZipPortableVersions(entry, releases)
-	case "msi":
-		return buildInstallerVersions(entry, releases, "msi", ".msi")
-	case "exe":
-		return buildInstallerVersions(entry, releases, "exe", ".exe")
+	case InstallerTypeMsi:
+		return buildInstallerVersions(entry, releases, InstallerTypeMsi, ".msi")
+	case InstallerTypeExe:
+		return buildInstallerVersions(entry, releases, InstallerTypeExe, ".exe")
 	default:
 		return nil, fmt.Errorf("unknown installer type: %s", entry.InstallerType)
 	}

--- a/gitlab.go
+++ b/gitlab.go
@@ -44,7 +44,7 @@ func (g Gitlab) FetchVersions(entry PackageListEntry) ([]Version, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		contents, _ := io.ReadAll(res.Body)
+		contents, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 		return nil, fmt.Errorf("gitlab releases API status %d: %s", res.StatusCode, contents)
 	}
 

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestGitlab_FetchVersions_ZipPortable(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	versions, err := g.FetchVersions(entry)
+	versions, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestGitlab_FetchVersions_Exe(t *testing.T) {
 		InstallerType: InstallerTypeExe,
 	}
 
-	versions, err := g.FetchVersions(entry)
+	versions, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestGitlab_FetchVersions_ErrorResponse(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err == nil {
 		t.Fatal("expected error for non-200 status")
 	}
@@ -150,7 +151,7 @@ func TestGitlab_FetchVersions_WithToken(t *testing.T) {
 		InstallerType: InstallerTypeZipPortable,
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestGitlab_FetchVersions_UnknownInstallerType(t *testing.T) {
 		InstallerType: "unknown-type",
 	}
 
-	_, err := g.FetchVersions(entry)
+	_, err := g.FetchVersions(context.Background(), entry)
 	if err == nil {
 		t.Fatal("expected error for unknown installer type")
 	}

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGitlab_FetchVersions_ZipPortable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []gitlabRelease{
+			{
+				Name: "v1.0.0",
+				Assets: gitlabAssets{
+					Links: []gitlabAssetLink{
+						{
+							Name:     "myapp_windows_x64.zip",
+							Url:      "https://example.com/myapp_windows_x64.zip",
+							LinkType: "package",
+						},
+						{
+							Name:     "myapp_linux_x64.tar.gz",
+							Url:      "https://example.com/myapp_linux_x64.tar.gz",
+							LinkType: "package",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Gitlab{httpClient: ts.Client()}
+
+	entry := PackageListEntry{
+		Endpoint:      ts.URL,
+		ProjectID:     42,
+		Name:          "myapp",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	versions, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+
+	if versions[0].Version != "v1.0.0" {
+		t.Errorf("expected version 'v1.0.0', got '%s'", versions[0].Version)
+	}
+
+	if len(versions[0].Installers) != 1 {
+		t.Fatalf("expected 1 installer, got %d", len(versions[0].Installers))
+	}
+
+	if versions[0].Installers[0].Architecture != "x64" {
+		t.Errorf("expected architecture 'x64', got '%s'", versions[0].Installers[0].Architecture)
+	}
+}
+
+func TestGitlab_FetchVersions_Exe(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []gitlabRelease{
+			{
+				Name: "v3.0.0",
+				Assets: gitlabAssets{
+					Links: []gitlabAssetLink{
+						{
+							Name:     "myapp_windows_x64.exe",
+							Url:      "https://example.com/myapp_windows_x64.exe",
+							LinkType: "package",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Gitlab{httpClient: ts.Client()}
+
+	entry := PackageListEntry{
+		Endpoint:      ts.URL,
+		ProjectID:     42,
+		Name:          "myapp",
+		InstallerType: InstallerTypeExe,
+	}
+
+	versions, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+
+	if versions[0].Installers[0].InstallerType != InstallerTypeExe {
+		t.Errorf("expected InstallerType '%s', got '%s'", InstallerTypeExe, versions[0].Installers[0].InstallerType)
+	}
+}
+
+func TestGitlab_FetchVersions_ErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"403 Forbidden"}`))
+	}))
+	defer ts.Close()
+
+	g := Gitlab{httpClient: ts.Client()}
+
+	entry := PackageListEntry{
+		Endpoint:      ts.URL,
+		ProjectID:     42,
+		Name:          "myapp",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestGitlab_FetchVersions_WithToken(t *testing.T) {
+	var gotToken string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("PRIVATE-TOKEN")
+		releases := []gitlabRelease{}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Gitlab{httpClient: ts.Client()}
+
+	entry := PackageListEntry{
+		Endpoint:      ts.URL,
+		ProjectID:     42,
+		Name:          "myapp",
+		Token:         "mysecrettoken",
+		InstallerType: InstallerTypeZipPortable,
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotToken != "mysecrettoken" {
+		t.Errorf("expected PRIVATE-TOKEN 'mysecrettoken', got '%s'", gotToken)
+	}
+}
+
+func TestGitlab_FetchVersions_UnknownInstallerType(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []gitlabRelease{{Name: "v1.0.0"}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+	defer ts.Close()
+
+	g := Gitlab{httpClient: ts.Client()}
+
+	entry := PackageListEntry{
+		Endpoint:      ts.URL,
+		ProjectID:     42,
+		Name:          "myapp",
+		InstallerType: "unknown-type",
+	}
+
+	_, err := g.FetchVersions(entry)
+	if err == nil {
+		t.Fatal("expected error for unknown installer type")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.2
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,5 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handler.go
+++ b/handler.go
@@ -31,7 +31,7 @@ func NewWingetSrcHandler(service WingetSrcService) http.Handler {
 	})
 
 	r.Get("/information", func(w http.ResponseWriter, r *http.Request) {
-		res, err := service.Information()
+		res, err := service.Information(r.Context())
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 				{
@@ -56,7 +56,7 @@ func NewWingetSrcHandler(service WingetSrcService) http.Handler {
 			return
 		}
 
-		res, err := service.ManifestSearch(req)
+		res, err := service.ManifestSearch(r.Context(), req)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 				{
@@ -74,7 +74,7 @@ func NewWingetSrcHandler(service WingetSrcService) http.Handler {
 		identifier := chi.URLParam(r, "identifier")
 		version := r.URL.Query().Get("Version")
 
-		res, err := service.PackageManifests(identifier, version)
+		res, err := service.PackageManifests(r.Context(), identifier, version)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 				{

--- a/handler_test.go
+++ b/handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,15 +17,15 @@ type mockService struct {
 	err          error
 }
 
-func (m mockService) Information() (InformationResponse, error) {
+func (m mockService) Information(ctx context.Context) (InformationResponse, error) {
 	return m.infoResp, m.err
 }
 
-func (m mockService) ManifestSearch(req ManifestSearchRequest) (ManifestSearchResponse, error) {
+func (m mockService) ManifestSearch(ctx context.Context, req ManifestSearchRequest) (ManifestSearchResponse, error) {
 	return m.searchResp, m.err
 }
 
-func (m mockService) PackageManifests(identifier string, version string) (PackageManifestsResponse, error) {
+func (m mockService) PackageManifests(ctx context.Context, identifier string, version string) (PackageManifestsResponse, error) {
 	if m.err != nil {
 		return PackageManifestsResponse{}, m.err
 	}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,10 @@ func run() int {
 		return exitErr
 	}
 
-	repository, err := NewWingetSrcRepository(packageListPath)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	repository, err := NewWingetSrcRepository(ctx, packageListPath)
 	if err != nil {
 		slog.Error(err.Error())
 		return exitErr
@@ -44,10 +47,6 @@ func run() int {
 		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-
-	defer stop()
 
 	go func() {
 		slog.Info("start server listen")

--- a/main.go
+++ b/main.go
@@ -40,6 +40,9 @@ func run() int {
 		Addr:              ":" + port,
 		Handler:           handler,
 		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/main.go
+++ b/main.go
@@ -49,8 +49,8 @@ func run() int {
 	go func() {
 		slog.Info("start server listen")
 
-		if err := srv.ListenAndServe(); err != nil && errors.Is(err, http.ErrServerClosed) {
-			slog.Info(err.Error())
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error(err.Error())
 		}
 	}()
 

--- a/provider_common.go
+++ b/provider_common.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var httpClient = &http.Client{
+var defaultHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
@@ -35,11 +35,11 @@ func detectArch(lname string) (string, bool) {
 	return "", false
 }
 
-func collectChecksums(assets []releaseAsset) (map[string]string, error) {
+func collectChecksums(client *http.Client, assets []releaseAsset) (map[string]string, error) {
 	checksums := map[string]string{}
 	for _, asset := range assets {
 		if asset.IsChecksum {
-			cs, err := fetchChecksums(asset.DownloadUrl)
+			cs, err := fetchChecksums(client, asset.DownloadUrl)
 			if err != nil {
 				return nil, err
 			}
@@ -51,10 +51,10 @@ func collectChecksums(assets []releaseAsset) (map[string]string, error) {
 	return checksums, nil
 }
 
-func buildVersions(releases []release, buildInstallers func(rel release, checksums map[string]string) []Installer) ([]Version, error) {
+func buildVersions(client *http.Client, releases []release, buildInstallers func(rel release, checksums map[string]string) []Installer) ([]Version, error) {
 	versions := []Version{}
 	for _, rel := range releases {
-		checksums, err := collectChecksums(rel.Assets)
+		checksums, err := collectChecksums(client, rel.Assets)
 		if err != nil {
 			return nil, err
 		}
@@ -70,8 +70,8 @@ func buildVersions(releases []release, buildInstallers func(rel release, checksu
 	return versions, nil
 }
 
-func buildZipPortableVersions(entry PackageListEntry, releases []release) ([]Version, error) {
-	return buildVersions(releases, func(rel release, checksums map[string]string) []Installer {
+func buildZipPortableVersions(client *http.Client, entry PackageListEntry, releases []release) ([]Version, error) {
+	return buildVersions(client, releases, func(rel release, checksums map[string]string) []Installer {
 		installers := []Installer{}
 		for _, asset := range rel.Assets {
 			lname := strings.ToLower(asset.Name)
@@ -98,8 +98,8 @@ func buildZipPortableVersions(entry PackageListEntry, releases []release) ([]Ver
 	})
 }
 
-func buildInstallerVersions(entry PackageListEntry, releases []release, installerType string, ext string) ([]Version, error) {
-	return buildVersions(releases, func(rel release, checksums map[string]string) []Installer {
+func buildInstallerVersions(client *http.Client, entry PackageListEntry, releases []release, installerType string, ext string) ([]Version, error) {
+	return buildVersions(client, releases, func(rel release, checksums map[string]string) []Installer {
 		installers := []Installer{}
 		for _, asset := range rel.Assets {
 			lname := strings.ToLower(asset.Name)
@@ -122,8 +122,8 @@ func buildInstallerVersions(entry PackageListEntry, releases []release, installe
 	})
 }
 
-func fetchChecksums(url string) (map[string]string, error) {
-	res, err := httpClient.Get(url)
+func fetchChecksums(client *http.Client, url string) (map[string]string, error) {
+	res, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("checksum download: %w", err)
 	}

--- a/provider_common.go
+++ b/provider_common.go
@@ -51,100 +51,75 @@ func collectChecksums(assets []releaseAsset) (map[string]string, error) {
 	return checksums, nil
 }
 
-func buildZipPortableVersions(entry PackageListEntry, releases []release) ([]Version, error) {
+func buildVersions(releases []release, buildInstallers func(rel release, checksums map[string]string) []Installer) ([]Version, error) {
 	versions := []Version{}
-
 	for _, rel := range releases {
 		checksums, err := collectChecksums(rel.Assets)
 		if err != nil {
 			return nil, err
 		}
+		installers := buildInstallers(rel, checksums)
+		if len(installers) == 0 {
+			continue
+		}
+		versions = append(versions, Version{
+			Version:    rel.Name,
+			Installers: installers,
+		})
+	}
+	return versions, nil
+}
 
+func buildZipPortableVersions(entry PackageListEntry, releases []release) ([]Version, error) {
+	return buildVersions(releases, func(rel release, checksums map[string]string) []Installer {
 		installers := []Installer{}
 		for _, asset := range rel.Assets {
 			lname := strings.ToLower(asset.Name)
 			if !(strings.Contains(lname, "windows") && strings.HasSuffix(lname, ".zip")) {
 				continue
 			}
-
 			arch, ok := detectArch(lname)
 			if !ok {
 				continue
 			}
-
-			checksum := checksums[asset.Name]
-
 			installers = append(installers, Installer{
 				Architecture:        arch,
 				InstallerType:       "zip",
 				InstallerUrl:        asset.DownloadUrl,
-				InstallerSha256:     checksum,
+				InstallerSha256:     checksums[asset.Name],
 				Scope:               "user",
 				NestedInstallerType: "portable",
 				NestedInstallerFiles: []NestedInstallerFile{
-					{
-						RelativeFilePath: fmt.Sprintf("%s.exe", entry.Name),
-					},
+					{RelativeFilePath: fmt.Sprintf("%s.exe", entry.Name)},
 				},
 			})
 		}
-
-		if len(installers) == 0 {
-			continue
-		}
-
-		versions = append(versions, Version{
-			Version:    rel.Name,
-			Installers: installers,
-		})
-	}
-
-	return versions, nil
+		return installers
+	})
 }
 
 func buildInstallerVersions(entry PackageListEntry, releases []release, installerType string, ext string) ([]Version, error) {
-	versions := []Version{}
-
-	for _, rel := range releases {
-		checksums, err := collectChecksums(rel.Assets)
-		if err != nil {
-			return nil, err
-		}
-
+	return buildVersions(releases, func(rel release, checksums map[string]string) []Installer {
 		installers := []Installer{}
 		for _, asset := range rel.Assets {
 			lname := strings.ToLower(asset.Name)
 			if !(strings.Contains(lname, "windows") && strings.HasSuffix(lname, ext)) {
 				continue
 			}
-
 			arch, ok := detectArch(lname)
 			if !ok {
 				continue
 			}
-
-			checksum := checksums[asset.Name]
-
 			installers = append(installers, Installer{
 				Architecture:    arch,
 				InstallerType:   installerType,
 				InstallerUrl:    asset.DownloadUrl,
-				InstallerSha256: checksum,
+				InstallerSha256: checksums[asset.Name],
 				Scope:           "user",
 			})
 		}
-
-		if len(installers) == 0 {
-			continue
-		}
-
-		versions = append(versions, Version{
-			Version:    rel.Name,
-			Installers: installers,
-		})
-	}
-
-	return versions, nil
+		return installers
+	})
 }
 
 func fetchChecksums(url string) (map[string]string, error) {

--- a/provider_common.go
+++ b/provider_common.go
@@ -25,11 +25,11 @@ type release struct {
 }
 
 func detectArch(lname string) (string, bool) {
-	if strings.Contains(lname, "x86_64") || strings.Contains(lname, "x64") {
+	if strings.Contains(lname, "x86_64") || strings.Contains(lname, "x64") || strings.Contains(lname, "amd64") {
 		return "x64", true
 	} else if strings.Contains(lname, "i386") || strings.Contains(lname, "x86") {
 		return "x86", true
-	} else if strings.Contains(lname, "arm64") {
+	} else if strings.Contains(lname, "arm64") || strings.Contains(lname, "aarch64") {
 		return "arm64", true
 	}
 	return "", false

--- a/provider_common_test.go
+++ b/provider_common_test.go
@@ -15,9 +15,11 @@ func TestDetectArch(t *testing.T) {
 	}{
 		{"app_windows_x86_64.zip", "x64", true},
 		{"app_windows_x64.zip", "x64", true},
+		{"app_windows_amd64.zip", "x64", true},
 		{"app_windows_i386.zip", "x86", true},
 		{"app_windows_x86.zip", "x86", true},
 		{"app_windows_arm64.zip", "arm64", true},
+		{"app_windows_aarch64.zip", "arm64", true},
 		{"app_linux_x64.tar.gz", "x64", true},
 		{"app_windows.zip", "", false},
 		{"app.zip", "", false},
@@ -47,7 +49,7 @@ func TestBuildZipPortableVersions(t *testing.T) {
 		},
 	}
 
-	versions, err := buildZipPortableVersions(entry, releases)
+	versions, err := buildZipPortableVersions(http.DefaultClient, entry, releases)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,7 +91,7 @@ func TestBuildZipPortableVersions_NoMatch(t *testing.T) {
 		},
 	}
 
-	versions, err := buildZipPortableVersions(entry, releases)
+	versions, err := buildZipPortableVersions(http.DefaultClient, entry, releases)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,7 +114,7 @@ func TestBuildInstallerVersions_Msi(t *testing.T) {
 		},
 	}
 
-	versions, err := buildInstallerVersions(entry, releases, "msi", ".msi")
+	versions, err := buildInstallerVersions(http.DefaultClient, entry, releases, "msi", ".msi")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +149,7 @@ func TestBuildInstallerVersions_NoMatch(t *testing.T) {
 		},
 	}
 
-	versions, err := buildInstallerVersions(entry, releases, "exe", ".exe")
+	versions, err := buildInstallerVersions(http.DefaultClient, entry, releases, "exe", ".exe")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +166,7 @@ func TestFetchChecksums_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	checksums, err := fetchChecksums(ts.URL)
+	checksums, err := fetchChecksums(ts.Client(), ts.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -189,7 +191,7 @@ func TestFetchChecksums_BadStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := fetchChecksums(ts.URL)
+	_, err := fetchChecksums(ts.Client(), ts.URL)
 	if err == nil {
 		t.Fatal("expected error for non-200 status")
 	}
@@ -201,7 +203,7 @@ func TestFetchChecksums_BadFormat(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := fetchChecksums(ts.URL)
+	_, err := fetchChecksums(ts.Client(), ts.URL)
 	if err == nil {
 		t.Fatal("expected error for bad checksum format")
 	}

--- a/repository.go
+++ b/repository.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -158,7 +159,7 @@ func dispatchProvider(entry PackageListEntry) (PackageProvider, error) {
 	}
 }
 
-func NewWingetSrcRepository(packageListPath string) (WingetSrcRepository, error) {
+func NewWingetSrcRepository(ctx context.Context, packageListPath string) (WingetSrcRepository, error) {
 	f, err := os.Open(packageListPath)
 	if err != nil {
 		return nil, err
@@ -170,8 +171,11 @@ func NewWingetSrcRepository(packageListPath string) (WingetSrcRepository, error)
 		return nil, err
 	}
 
+	cache := NewCache[[]Version](5 * time.Minute)
+	cache.StartCleanup(ctx, 10*time.Minute)
+
 	return WingetSrcRepositoryImpl{
 		packageList:  packageList,
-		versionCache: NewCache[[]Version](5 * time.Minute),
+		versionCache: cache,
 	}, nil
 }

--- a/repository.go
+++ b/repository.go
@@ -13,8 +13,8 @@ import (
 type QueryManifestCondition func(PackageListEntry) bool
 
 type WingetSrcRepository interface {
-	QueryManifest(condition QueryManifestCondition) ([]Manifest, error)
-	QueryPackageManifests(identifier string) (PackageManifests, error)
+	QueryManifest(ctx context.Context, condition QueryManifestCondition) ([]Manifest, error)
+	QueryPackageManifests(ctx context.Context, identifier string) (PackageManifests, error)
 }
 
 type WingetSrcRepositoryImpl struct {
@@ -58,7 +58,7 @@ func And(conditions ...QueryManifestCondition) QueryManifestCondition {
 	}
 }
 
-func (w WingetSrcRepositoryImpl) fetchVersionsCached(entry PackageListEntry) ([]Version, error) {
+func (w WingetSrcRepositoryImpl) fetchVersionsCached(ctx context.Context, entry PackageListEntry) ([]Version, error) {
 	if cached, ok := w.versionCache.Get(entry.Id); ok {
 		return cached, nil
 	}
@@ -68,7 +68,7 @@ func (w WingetSrcRepositoryImpl) fetchVersionsCached(entry PackageListEntry) ([]
 		return nil, fmt.Errorf("unknown package provider")
 	}
 
-	versions, err := provider.FetchVersions(entry)
+	versions, err := provider.FetchVersions(ctx, entry)
 	if err != nil {
 		return nil, fmt.Errorf("fetch versions: %w", err)
 	}
@@ -77,7 +77,7 @@ func (w WingetSrcRepositoryImpl) fetchVersionsCached(entry PackageListEntry) ([]
 	return versions, nil
 }
 
-func (w WingetSrcRepositoryImpl) QueryManifest(condition QueryManifestCondition) ([]Manifest, error) {
+func (w WingetSrcRepositoryImpl) QueryManifest(ctx context.Context, condition QueryManifestCondition) ([]Manifest, error) {
 	manifests := []Manifest{}
 
 	for _, entry := range w.packageList {
@@ -85,7 +85,7 @@ func (w WingetSrcRepositoryImpl) QueryManifest(condition QueryManifestCondition)
 			continue
 		}
 
-		versions, err := w.fetchVersionsCached(entry)
+		versions, err := w.fetchVersionsCached(ctx, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +109,7 @@ func (w WingetSrcRepositoryImpl) QueryManifest(condition QueryManifestCondition)
 	return manifests, nil
 }
 
-func (w WingetSrcRepositoryImpl) QueryPackageManifests(identifier string) (PackageManifests, error) {
+func (w WingetSrcRepositoryImpl) QueryPackageManifests(ctx context.Context, identifier string) (PackageManifests, error) {
 	var found PackageListEntry
 	for _, entry := range w.packageList {
 		if strings.EqualFold(entry.Id, identifier) {
@@ -122,7 +122,7 @@ func (w WingetSrcRepositoryImpl) QueryPackageManifests(identifier string) (Packa
 		return PackageManifests{}, nil
 	}
 
-	versions, err := w.fetchVersionsCached(found)
+	versions, err := w.fetchVersionsCached(ctx, found)
 	if err != nil {
 		return PackageManifests{}, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -151,9 +151,9 @@ func (w WingetSrcRepositoryImpl) QueryPackageManifests(identifier string) (Packa
 func dispatchProvider(entry PackageListEntry) (PackageProvider, error) {
 	switch entry.Provider {
 	case "github":
-		return Github{}, nil
+		return Github{httpClient: defaultHTTPClient}, nil
 	case "gitlab":
-		return Gitlab{}, nil
+		return Gitlab{httpClient: defaultHTTPClient}, nil
 	default:
 		return nil, fmt.Errorf("unknown package provider")
 	}

--- a/repository.go
+++ b/repository.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type QueryManifestCondition func(PackageListEntry) bool

--- a/repository.go
+++ b/repository.go
@@ -111,7 +111,7 @@ func (w WingetSrcRepositoryImpl) QueryManifest(condition QueryManifestCondition)
 func (w WingetSrcRepositoryImpl) QueryPackageManifests(identifier string) (PackageManifests, error) {
 	var found PackageListEntry
 	for _, entry := range w.packageList {
-		if entry.Id == identifier {
+		if strings.EqualFold(entry.Id, identifier) {
 			found = entry
 			break
 		}

--- a/service.go
+++ b/service.go
@@ -87,7 +87,6 @@ func (w WingetSrcServiceImpl) PackageManifests(identifier string, version string
 		for _, v := range res.Versions {
 			if v.PackageVersion == version {
 				found = append(found, v)
-				break
 			}
 		}
 

--- a/service.go
+++ b/service.go
@@ -1,11 +1,14 @@
 package main
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type WingetSrcService interface {
-	Information() (InformationResponse, error)
-	ManifestSearch(req ManifestSearchRequest) (ManifestSearchResponse, error)
-	PackageManifests(identifier string, version string) (PackageManifestsResponse, error)
+	Information(ctx context.Context) (InformationResponse, error)
+	ManifestSearch(ctx context.Context, req ManifestSearchRequest) (ManifestSearchResponse, error)
+	PackageManifests(ctx context.Context, identifier string, version string) (PackageManifestsResponse, error)
 }
 
 type WingetSrcServiceImpl struct {
@@ -18,7 +21,7 @@ func NewWingetSrcService(repository WingetSrcRepository) WingetSrcService {
 	}
 }
 
-func (w WingetSrcServiceImpl) Information() (InformationResponse, error) {
+func (w WingetSrcServiceImpl) Information(ctx context.Context) (InformationResponse, error) {
 	return InformationResponse{
 		SourceIdentifier: "api.winget-src",
 		ServerSupportedVersions: []string{
@@ -27,7 +30,7 @@ func (w WingetSrcServiceImpl) Information() (InformationResponse, error) {
 		},
 	}, nil
 }
-func (w WingetSrcServiceImpl) ManifestSearch(req ManifestSearchRequest) (ManifestSearchResponse, error) {
+func (w WingetSrcServiceImpl) ManifestSearch(ctx context.Context, req ManifestSearchRequest) (ManifestSearchResponse, error) {
 	conditions := []QueryManifestCondition{}
 
 	if req.Query.Keyword != "" {
@@ -64,7 +67,7 @@ func (w WingetSrcServiceImpl) ManifestSearch(req ManifestSearchRequest) (Manifes
 		conditions = append(conditions, And(andConds...))
 	}
 
-	manifests, err := w.repository.QueryManifest(And(conditions...))
+	manifests, err := w.repository.QueryManifest(ctx, And(conditions...))
 	if err != nil {
 		return ManifestSearchResponse{}, err
 	}
@@ -72,8 +75,8 @@ func (w WingetSrcServiceImpl) ManifestSearch(req ManifestSearchRequest) (Manifes
 	return manifests, nil
 }
 
-func (w WingetSrcServiceImpl) PackageManifests(identifier string, version string) (PackageManifestsResponse, error) {
-	res, err := w.repository.QueryPackageManifests(identifier)
+func (w WingetSrcServiceImpl) PackageManifests(ctx context.Context, identifier string, version string) (PackageManifestsResponse, error) {
+	res, err := w.repository.QueryPackageManifests(ctx, identifier)
 	if err != nil {
 		return PackageManifestsResponse{}, err
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -11,7 +12,7 @@ type mockRepository struct {
 	err             error
 }
 
-func (m mockRepository) QueryManifest(condition QueryManifestCondition) ([]Manifest, error) {
+func (m mockRepository) QueryManifest(ctx context.Context, condition QueryManifestCondition) ([]Manifest, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -28,7 +29,7 @@ func (m mockRepository) QueryManifest(condition QueryManifestCondition) ([]Manif
 	return result, nil
 }
 
-func (m mockRepository) QueryPackageManifests(identifier string) (PackageManifests, error) {
+func (m mockRepository) QueryPackageManifests(ctx context.Context, identifier string) (PackageManifests, error) {
 	if m.err != nil {
 		return PackageManifests{}, m.err
 	}
@@ -40,7 +41,7 @@ func (m mockRepository) QueryPackageManifests(identifier string) (PackageManifes
 
 func TestInformation(t *testing.T) {
 	svc := NewWingetSrcService(mockRepository{})
-	info, err := svc.Information()
+	info, err := svc.Information(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestManifestSearch_ByKeyword(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.ManifestSearch(ManifestSearchRequest{
+	res, err := svc.ManifestSearch(context.Background(), ManifestSearchRequest{
 		Query: Query{Keyword: "foo"},
 	})
 	if err != nil {
@@ -84,7 +85,7 @@ func TestManifestSearch_ByFilter(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.ManifestSearch(ManifestSearchRequest{
+	res, err := svc.ManifestSearch(context.Background(), ManifestSearchRequest{
 		Filters: []FieldQuery{
 			{PackageMatchField: PackageMatchFieldPackageIdentifier, RequestMatch: Query{Keyword: "owner/bar"}},
 		},
@@ -109,7 +110,7 @@ func TestManifestSearch_ByInclusion(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.ManifestSearch(ManifestSearchRequest{
+	res, err := svc.ManifestSearch(context.Background(), ManifestSearchRequest{
 		Inclusions: []FieldQuery{
 			{PackageMatchField: PackageMatchFieldPackageName, RequestMatch: Query{Keyword: "bar"}},
 		},
@@ -129,7 +130,7 @@ func TestManifestSearch_RepositoryError(t *testing.T) {
 	repo := mockRepository{err: fmt.Errorf("repository error")}
 	svc := NewWingetSrcService(repo)
 
-	_, err := svc.ManifestSearch(ManifestSearchRequest{Query: Query{Keyword: "foo"}})
+	_, err := svc.ManifestSearch(context.Background(), ManifestSearchRequest{Query: Query{Keyword: "foo"}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -147,7 +148,7 @@ func TestPackageManifests_Found(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.PackageManifests("owner/foo", "")
+	res, err := svc.PackageManifests(context.Background(), "owner/foo", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestPackageManifests_WithVersion(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.PackageManifests("owner/foo", "2.0.0")
+	res, err := svc.PackageManifests(context.Background(), "owner/foo", "2.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestPackageManifests_VersionNotFound(t *testing.T) {
 	}
 	svc := NewWingetSrcService(repo)
 
-	_, err := svc.PackageManifests("owner/foo", "9.9.9")
+	_, err := svc.PackageManifests(context.Background(), "owner/foo", "9.9.9")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -201,7 +202,7 @@ func TestPackageManifests_NotFound(t *testing.T) {
 	repo := mockRepository{}
 	svc := NewWingetSrcService(repo)
 
-	res, err := svc.PackageManifests("nonexistent", "")
+	res, err := svc.PackageManifests(context.Background(), "nonexistent", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package main
 
+import "context"
+
 const (
 	InstallerTypeZipPortable = "zip-portable"
 	InstallerTypeMsi         = "msi"
@@ -24,5 +26,5 @@ type Version struct {
 }
 
 type PackageProvider interface {
-	FetchVersions(PackageListEntry) ([]Version, error)
+	FetchVersions(ctx context.Context, entry PackageListEntry) ([]Version, error)
 }

--- a/types.go
+++ b/types.go
@@ -1,5 +1,11 @@
 package main
 
+const (
+	InstallerTypeZipPortable = "zip-portable"
+	InstallerTypeMsi         = "msi"
+	InstallerTypeExe         = "exe"
+)
+
 type PackageListEntry struct {
 	Provider      string `yaml:"provider"`
 	Id            string `yaml:"id"`


### PR DESCRIPTION
## Summary

- **バグ修正**: `ListenAndServe` エラーハンドリング修正（`ErrServerClosed` 以外を `slog.Error` で報告）
- **バグ修正**: APIエラーレスポンスの `io.ReadAll` に `io.LimitReader`（1MB上限）を適用（github/gitlab）
- **機能追加**: `detectArch` に `amd64` / `aarch64` の別名を追加
- **機能追加**: HTTP サーバーに `ReadTimeout` / `WriteTimeout` / `IdleTimeout` を追加
- **機能追加**: `Cache.StartCleanup` で TTL 期限切れエントリを定期削除（メモリリーク対策）
- **機能追加**: 全層（Handler → Service → Repository → Provider）に `context.Context` を導入
- **リファクタリング**: `InstallerType` の有効値を定数化し switch 文のハードコードを置換
- **リファクタリング**: `buildVersions` ヘルパーで `buildZipPortable`/`buildInstaller` の共通ロジックを統合
- **リファクタリング**: `httpClient` をグローバル変数からプロバイダー構造体のフィールドに注入（テスタビリティ向上）
- **テスト追加**: `github.go` / `gitlab.go` の httptest モックサーバーによるユニットテスト追加
- **依存更新**: `gopkg.in/yaml.v2` → `v3` へ移行

## Test plan

- [ ] `go test ./...` がすべて通ることを確認
- [ ] `go build ./...` がビルドできることを確認
- [ ] `ListenAndServe` エラーハンドリングが正常に動作することを確認（ポート競合時に `slog.Error` が出力される）
- [ ] context キャンセル時にリクエストが適切に中断されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)